### PR TITLE
Add essential network tools to Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Network tools
     iputils-ping \
     dnsutils \
+    iproute2 \
+    net-tools \
     # Clean up to reduce layer size
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/src/modules/environment.py
+++ b/src/modules/environment.py
@@ -24,7 +24,9 @@ def auto_setup() -> List[str]:
         'gobuster': 'Directory/file brute-forcer',
         'netcat': 'Network utility for reading/writing data',
         'curl': 'HTTP client for web requests',
-        'metasploit': 'Penetration testing framework'
+        'metasploit': 'Penetration testing framework',
+        'iproute2': 'Provides modern networking tools (ip, ss, tc, etc.)',
+        'net-tools': 'Provides classic networking utilities (netstat, ifconfig, route, etc.)',
     }
     
     available_tools = []


### PR DESCRIPTION
This commit adds iproute2 and net-tools packages to the Dockerfile to provide essential network utilities for cybersecurity operations:

- iproute2: Provides modern networking tools (ip, ss, tc, etc.)
- net-tools: Provides classic networking utilities (netstat, ifconfig, route, etc.)

These tools are commonly needed for network analysis and troubleshooting during security assessments, complementing the existing security toolset.