### PR TITLE
feat: add configurable default timeout for browser tools

### DIFF
--- a/src/modules/tools/browser.py
+++ b/src/modules/tools/browser.py
@@ -174,6 +174,7 @@ class BrowserService(EventEmitter):
         if self._initialized:
             return
 
+        logger.info("Initializing browser")
         await self.stagehand.init()
         self._initialized = True
 
@@ -595,11 +596,9 @@ async def get_browser():
     """
     if not _BROWSER:
         raise ValueError("Browser not initialized. Please call initialize_browser first.")
-    logger.info("[BROWSER] ENtering get_browser context manager.")
+
     async with _BROWSER_LOCK:
-        logger.info("[BROWSER] ENtering get_browser context manager lock.")
         await _BROWSER.ensure_init()
-        logger.info("[BROWSER] Done get_browser context manager ensure_init.")
         yield _BROWSER
 
 


### PR DESCRIPTION
Follow up to https://github.com/westonbrown/Cyber-AutoAgent/pull/84

- Introduce `default_timeout` in the browser initialization allowing dynamic timeout configuration via the `BROWSER_DEFAULT_TIMEOUT` environment variable.
- Add an asynchronous context manager `timeout` to  apply the default timeout across multiple browser operations.
- Update browser tool functions to utilize the new `timeout` context.
- Ensure default timeouts are applied for navigation, page actions, and observations, improving reliability in handling long-running browser tasks.